### PR TITLE
APP-586 Welcome messages blocked by Origin Check filter

### DIFF
--- a/integration-web/src/main/java/org/symphonyoss/integration/web/filter/WebHookOriginCheckFilter.java
+++ b/integration-web/src/main/java/org/symphonyoss/integration/web/filter/WebHookOriginCheckFilter.java
@@ -73,8 +73,6 @@ public class WebHookOriginCheckFilter implements Filter {
 
   private static final String WEBHOOK_FILTER = "Webhook Filter";
 
-  private static final String ACCEPTABLE_ORIGINS_KEY = "acceptable_origins";
-
   private static final String FORBIDDEN_MESSAGE = "Host not allowed";
 
   private static final String WELCOME_PATH = "welcome";
@@ -166,7 +164,7 @@ public class WebHookOriginCheckFilter implements Filter {
         LOGGER.warn(ExceptionMessageFormatter.format(WEBHOOK_FILTER,
             logMessage.getMessage(WEBHOOK_REQUEST_BLOCKED, remoteAddressInfo),
             logMessage.getMessage(WEBHOOK_REQUEST_BLOCKED_SOLUTION, integrationType)));
-        writeResponse(response, whiteList, remoteAddressInfo);
+        writeResponse(response, remoteAddressInfo);
       }
     }
   }
@@ -277,19 +275,16 @@ public class WebHookOriginCheckFilter implements Filter {
   /**
    * Write the http error response.
    * @param response Http response
-   * @param whiteList Integration whitelist
    * @param remoteAddress Origin remote address
    * @throws IOException Report failure to write the http error response.
    */
-  private void writeResponse(HttpServletResponse response, Set<String> whiteList,
-      String remoteAddress) throws IOException {
+  private void writeResponse(HttpServletResponse response, String remoteAddress) throws IOException {
     response.setContentType(APPLICATION_JSON);
     response.setStatus(Response.Status.FORBIDDEN.getStatusCode());
 
     ObjectNode message = JsonNodeFactory.instance.objectNode();
     message.put(INFO_KEY, FORBIDDEN_MESSAGE);
     message.put(ORIGIN_KEY, remoteAddress);
-    message.put(ACCEPTABLE_ORIGINS_KEY, whiteList.toString());
 
     response.getWriter().write(message.toString());
   }

--- a/integration-web/src/test/java/org/symphonyoss/integration/web/filter/WebHookOriginCheckFilterTest.java
+++ b/integration-web/src/test/java/org/symphonyoss/integration/web/filter/WebHookOriginCheckFilterTest.java
@@ -73,6 +73,10 @@ public class WebHookOriginCheckFilterTest {
 
   private static final String FORWARD_HEADER = "x-forwarded-for";
 
+  private static final String WEBHOOK_URL = "/integration/v1/whi/jiraWebHookIntegration/11111/22222";
+
+  private static final String WELCOME_URL = WEBHOOK_URL + "/welcome/";
+
   @InjectMocks
   private WebHookOriginCheckFilter filter = new WebHookOriginCheckFilter();
 
@@ -105,7 +109,7 @@ public class WebHookOriginCheckFilterTest {
     servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE,
         springContext);
 
-    doReturn("/integration/v1/whi/jiraWebHookIntegration/11111/22222").when(request).getRequestURI();
+    doReturn(WEBHOOK_URL).when(request).getRequestURI();
     doReturn(StringUtils.EMPTY).when(request).getContextPath();
     doReturn(servletContext).when(config).getServletContext();
     doReturn(integration).when(springContext).getBean(BEAN_NAME, Integration.class);
@@ -209,4 +213,13 @@ public class WebHookOriginCheckFilterTest {
     filter.doFilter(request, response, new MockFilterChain());
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
+
+  @Test
+  public void testWelcomeUrl() throws IOException, ServletException {
+    doReturn(WELCOME_URL).when(request).getRequestURI();
+
+    filter.doFilter(request, response, new MockFilterChain());
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
 }


### PR DESCRIPTION
- The origin checks implemented by the integration bridge are preventing the Configurator Apps to trigger the welcome message from the Symphony Web Client.