### PR TITLE
APP-911 / APP-797 cert ownership and optional import

### DIFF
--- a/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
+++ b/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
@@ -30,7 +30,15 @@ import org.symphonyoss.integration.model.yaml.IntegrationProperties;
 import org.symphonyoss.integration.provisioning.exception.KeyPairException;
 import org.symphonyoss.integration.utils.IntegrationUtils;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.List;
 import java.util.Locale;
 import java.util.Scanner;
@@ -58,8 +66,6 @@ public class KeyPairService {
 
   private static final String OPENSSL_PKCS12_CMD = "openssl pkcs12 -export -out %s -aes256 -in %s"
       + " -inkey %s -passin pass:%s -passout pass:%s";
-
-  private static final String CHANGE_OWNER_CMD = "chown %s:%s %s";
 
   @Autowired
   private IntegrationProperties properties;
@@ -192,10 +198,22 @@ public class KeyPairService {
   private void setFileOwnership(String filename, String user, String group) {
     LOGGER.info("Setting ownership for {} ({}:{})", filename, user, group);
 
-    String changeOwnerCommand =
-        String.format(CHANGE_OWNER_CMD, user, group, filename);
+    UserPrincipalLookupService lookupService = FileSystems.getDefault().getUserPrincipalLookupService();
+    File targetFile = new File(filename);
+    PosixFileAttributeView fileAttributeView =
+        Files.getFileAttributeView(targetFile.toPath(), PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
 
-    executeProcess(changeOwnerCommand);
+    try {
+      UserPrincipal userPrincipal = lookupService.lookupPrincipalByName(user);
+      GroupPrincipal groupPrincipal = lookupService.lookupPrincipalByGroupName(group);
+      fileAttributeView.setOwner(userPrincipal);
+      fileAttributeView.setGroup(groupPrincipal);
+    } catch (IOException e) {
+      throw new KeyPairException(
+          String.format("Cannot set ownership for %s. Failed to lookup user or group (%s:%s)", filename, user, group),
+          e);
+    }
+
   }
 
   /**

--- a/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
+++ b/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
@@ -193,7 +193,7 @@ public class KeyPairService {
     LOGGER.info("Setting ownership for {} ({}:{})", filename, user, group);
 
     String changeOwnerCommand =
-        String.format(CHANGE_OWNER_CMD, filename, user, group);
+        String.format(CHANGE_OWNER_CMD, user, group, filename);
 
     executeProcess(changeOwnerCommand);
   }

--- a/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
+++ b/integration-provisioning/src/main/java/org/symphonyoss/integration/provisioning/service/KeyPairService.java
@@ -46,6 +46,10 @@ public class KeyPairService {
 
   private static final String DEFAULT_ORGANIZATION = "Symphony Communications LLC";
 
+  private static final String FILE_OWNERSHIP_USER = "ibridge";
+
+  private static final String FILE_OWNERSHIP_GROUP = "ibridge";
+
   private static final String OPENSSL_GEN_KEY_CMD = "openssl genrsa -aes256 -passout pass:%s -out"
       + " %s 2048";
 
@@ -54,6 +58,8 @@ public class KeyPairService {
 
   private static final String OPENSSL_PKCS12_CMD = "openssl pkcs12 -export -out %s -aes256 -in %s"
       + " -inkey %s -passin pass:%s -passout pass:%s";
+
+  private static final String CHANGE_OWNER_CMD = "chown %s:%s %s";
 
   @Autowired
   private IntegrationProperties properties;
@@ -175,6 +181,21 @@ public class KeyPairService {
     }
 
     executeProcess(genPKCS12Command);
+
+    setFileOwnership(appCertFilename, FILE_OWNERSHIP_USER, FILE_OWNERSHIP_GROUP);
+    setFileOwnership(appPKCS12Filename, FILE_OWNERSHIP_USER, FILE_OWNERSHIP_GROUP);
+  }
+
+  /**
+   * Sets the ownership of the given file with according to the user
+   */
+  private void setFileOwnership(String filename, String user, String group) {
+    LOGGER.info("Setting ownership for {} ({}:{})", filename, user, group);
+
+    String changeOwnerCommand =
+        String.format(CHANGE_OWNER_CMD, filename, user, group);
+
+    executeProcess(changeOwnerCommand);
   }
 
   /**

--- a/integration-provisioning/src/test/java/org/symphonyoss/integration/provisioning/service/CompanyCertificateServiceTest.java
+++ b/integration-provisioning/src/test/java/org/symphonyoss/integration/provisioning/service/CompanyCertificateServiceTest.java
@@ -17,6 +17,7 @@
 package org.symphonyoss.integration.provisioning.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -24,6 +25,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.symphonyoss.integration.provisioning.properties.AuthenticationProperties.DEFAULT_USER_ID;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,10 +134,11 @@ public class CompanyCertificateServiceTest {
     doReturn(MOCK_SESSION_ID).when(authenticationProxy).getSessionToken(DEFAULT_USER_ID);
   }
 
-  @Test(expected = CompanyCertificateException.class)
+  @Test
   public void testFileNotFound() {
     this.application.setId(UNKNOWN_ID);
-    service.getPem(application);
+    String pem = service.getPem(application);
+    assertTrue(StringUtils.isBlank(pem));
   }
 
   @Test(expected = CompanyCertificateException.class)

--- a/integration-provisioning/src/test/resources/log4j2.xml
+++ b/integration-provisioning/src/test/resources/log4j2.xml
@@ -1,74 +1,18 @@
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <Configuration>
 
-    <Properties>
-        <Property name="logs.basedir">/data/symphony/ib</Property>
-        <Property name="log4j2.logLevel">INFO</Property>
-        <Property name="log4j2.symphonyLogLevel">INFO</Property>
-        <Property name="log4j2.consoleLogThreshold">INFO</Property>
-        <Property name="log4j2.outputAllToConsole">false</Property>
-        <Property name="symphony.instanceId">integration-bridge</Property>
-        <Property name="symphony.maxLogsPerBulkRequest">10</Property>
-        <Property name="symphony.maxPayloadSize">100000</Property>
-    </Properties>
-
     <Appenders>
-
         <Console name="console" target="SYSTEM_OUT">
-            <ThresholdFilter level="${sys:log4j2.consoleLogThreshold}" onMatch="ACCEPT"
-                             onMismatch="DENY"/>
-            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %20c{1} %M [Trace ID: %X{X-Trace-Id}] - %m%n"/>
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %20c{1} %M %X{X-Trace-Id} - %m%n"/>
         </Console>
-
-        <RollingFile name="error-rolling-file"
-                     fileName="${sys:logs.basedir}/logs/integration-bridge-error.log"
-                     filePattern="${sys:logs.basedir}/logs/integration-bridge-error-%i.log.gz"
-                     immediateFlush="false">
-            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
-            <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
-            <DefaultRolloverStrategy max="10"/>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="100 MB"/>
-            </Policies>
-        </RollingFile>
-
-        <RollingFile name="rolling-file"
-                     fileName="${sys:logs.basedir}/logs/integration-bridge.log"
-                     filePattern="${sys:logs.basedir}/logs/integration-bridge-%i.log.gz"
-                     immediateFlush="false">
-            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
-            <DefaultRolloverStrategy max="10"/>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="100 MB"/>
-            </Policies>
-        </RollingFile>
-
-        <SymphonyOnPremHttpsAppender name="OnPremHttpsAppender" url="${sys:cloudLogHarvesterURL}"
-                                     maxLogsPerBulkRequest="${sys:symphony.maxLogsPerBulkRequest}"
-                                     maxLogsPerBulkRequestFromSink="${sys:symphony.maxLogsPerBulkRequest}"
-                                     maxPayloadSize="${sys:symphony.maxPayloadSize}" flushingInterval="5"
-                                     sinkFlushingInterval="5"
-                                     sinkFileName="${sys:logs.basedir}/logs/integration." instanceId="${sys:symphony.instanceId}"
-                                     sessionProviderClassName="com.symphony.integration.logging.IntegrationBridgeSessionProvider">
-            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
-        </SymphonyOnPremHttpsAppender>
-
     </Appenders>
 
     <Loggers>
-
-        <AsyncLogger name="org.symphonyoss" level="${sys:log4j2.symphonyLogLevel}" additivity="${sys:log4j2.outputAllToConsole}">
-            <AppenderRef ref="rolling-file"/>
-            <AppenderRef ref="error-rolling-file"/>
-            <AppenderRef ref="OnPremHttpsAppender" />
-        </AsyncLogger>
-
-        <AsyncRoot level="${sys:log4j2.logLevel}">
+        <AsyncRoot level="INFO">
             <AppenderRef ref="console"/>
-            <AppenderRef ref="error-rolling-file"/>
-            <AppenderRef ref="OnPremHttpsAppender" />
         </AsyncRoot>
-
     </Loggers>
 
 </Configuration>

--- a/integration-provisioning/src/test/resources/log4j2.xml
+++ b/integration-provisioning/src/test/resources/log4j2.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Configuration>
+
+    <Properties>
+        <Property name="logs.basedir">/data/symphony/ib</Property>
+        <Property name="log4j2.logLevel">INFO</Property>
+        <Property name="log4j2.symphonyLogLevel">INFO</Property>
+        <Property name="log4j2.consoleLogThreshold">INFO</Property>
+        <Property name="log4j2.outputAllToConsole">false</Property>
+        <Property name="symphony.instanceId">integration-bridge</Property>
+        <Property name="symphony.maxLogsPerBulkRequest">10</Property>
+        <Property name="symphony.maxPayloadSize">100000</Property>
+    </Properties>
+
+    <Appenders>
+
+        <Console name="console" target="SYSTEM_OUT">
+            <ThresholdFilter level="${sys:log4j2.consoleLogThreshold}" onMatch="ACCEPT"
+                             onMismatch="DENY"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %20c{1} %M [Trace ID: %X{X-Trace-Id}] - %m%n"/>
+        </Console>
+
+        <RollingFile name="error-rolling-file"
+                     fileName="${sys:logs.basedir}/logs/integration-bridge-error.log"
+                     filePattern="${sys:logs.basedir}/logs/integration-bridge-error-%i.log.gz"
+                     immediateFlush="false">
+            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
+            <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
+            <DefaultRolloverStrategy max="10"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="100 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <RollingFile name="rolling-file"
+                     fileName="${sys:logs.basedir}/logs/integration-bridge.log"
+                     filePattern="${sys:logs.basedir}/logs/integration-bridge-%i.log.gz"
+                     immediateFlush="false">
+            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
+            <DefaultRolloverStrategy max="10"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="100 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <SymphonyOnPremHttpsAppender name="OnPremHttpsAppender" url="${sys:cloudLogHarvesterURL}"
+                                     maxLogsPerBulkRequest="${sys:symphony.maxLogsPerBulkRequest}"
+                                     maxLogsPerBulkRequestFromSink="${sys:symphony.maxLogsPerBulkRequest}"
+                                     maxPayloadSize="${sys:symphony.maxPayloadSize}" flushingInterval="5"
+                                     sinkFlushingInterval="5"
+                                     sinkFileName="${sys:logs.basedir}/logs/integration." instanceId="${sys:symphony.instanceId}"
+                                     sessionProviderClassName="com.symphony.integration.logging.IntegrationBridgeSessionProvider">
+            <PatternLayout pattern="%d %-5p [%c] (%t) [Trace ID: %X{X-Trace-Id}] %m%n"/>
+        </SymphonyOnPremHttpsAppender>
+
+    </Appenders>
+
+    <Loggers>
+
+        <AsyncLogger name="org.symphonyoss" level="${sys:log4j2.symphonyLogLevel}" additivity="${sys:log4j2.outputAllToConsole}">
+            <AppenderRef ref="rolling-file"/>
+            <AppenderRef ref="error-rolling-file"/>
+            <AppenderRef ref="OnPremHttpsAppender" />
+        </AsyncLogger>
+
+        <AsyncRoot level="${sys:log4j2.logLevel}">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="error-rolling-file"/>
+            <AppenderRef ref="OnPremHttpsAppender" />
+        </AsyncRoot>
+
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
- Adding logic to set the owner of generated certs as ibridge:ibridge.
- Adding logic to optionally import PEM files (if they are not provided, will not be imported).

(This PR is done against the sprint-17.7-release and that branch will be merged into dev).